### PR TITLE
fix(controlbase): IgControlBase should not reference it's child IgGridBase

### DIFF
--- a/src/igcontrolbase/igcontrolbase.ts
+++ b/src/igcontrolbase/igcontrolbase.ts
@@ -1,5 +1,4 @@
 import { ElementRef, EventEmitter, Renderer, IterableDiffers, DoCheck } from '@angular/core';
-import { IgGridBase } from '../iggrid/iggridbase';
 
 declare var jQuery: any;
 
@@ -115,8 +114,8 @@ export class IgControlBase<Model> implements DoCheck {
 				jQuery.ui[this._widgetName].prototype.options.hasOwnProperty(name) &&
 				jQuery(this._el).data(this._widgetName)) {
 				jQuery(this._el)[this._widgetName]("option", name, value);
-				if(name === "dataSource" && this instanceof IgGridBase) {
-					this._dataSource = jQuery.extend(true, [], value);
+				if(name === "dataSource" && typeof this.createDataSource === 'function') {
+          this._dataSource = this.createDataSource(value);
 				}
 			}
 		}

--- a/src/iggrid/iggridbase.ts
+++ b/src/iggrid/iggridbase.ts
@@ -42,6 +42,10 @@ export class IgGridBase<Model> extends IgControlBase<Model> implements AfterCont
 		super.ngOnInit();
 	}
 
+	createDataSource(value: any) {
+    return jQuery.extend(true, [], value);
+	}
+
 	deleteRow(id) {
 		var element = jQuery(this._el),
 			tr = element.find("tr[data-id='" + id + "']");


### PR DESCRIPTION
fix #234 
`IgControlBase` is parent class should not reference it's child class `IgGridBase`.

I just added a base `factory` method to do the same thing.
